### PR TITLE
Added support for 'avif' and 'jp2' formats

### DIFF
--- a/cloudinary/apiCaller.js
+++ b/cloudinary/apiCaller.js
@@ -48,6 +48,7 @@ const sendToCloudinery = (imagesArray, batchSize, dpr, metaData, cb, rollBarMsg)
         return Object.assign(trans, {width: image.width, height: image.height, dpr: dpr || 1});
       });
     }
+
     cloudinary.v2.uploader.upload(image.url, {eager: eager, analyze:{context: context}, tags: timestamp},(error, result) => {
       if (error) {
         analyzeResults.push({public_id: null});

--- a/config/default.js
+++ b/config/default.js
@@ -44,6 +44,8 @@ const conf = {
     "transformations": process.env.CLOUDINARY_TRANSF || [
       {quality: 'auto', crop: 'limit'},
       {quality: 'auto', fetch_format: 'webp', flags: 'awebp', crop: 'limit'},
+      {quality: 'auto', fetch_format: 'jp2', crop: 'limit'},
+      {quality: 'auto', fetch_format: 'avif', crop: 'limit'},
       {quality: 'auto', fetch_format: 'wdp', crop: 'limit'},
       {quality: 'auto', fetch_format: 'png', flags: 'apng', crop: 'limit'}
     ]

--- a/config/wpt/custom_metrics.js
+++ b/config/wpt/custom_metrics.js
@@ -180,7 +180,7 @@ var result = function() {
       }
       return;
     } catch(e) { 
-      return; 
+      return;
     }
   };
 

--- a/logger/index.js
+++ b/logger/index.js
@@ -23,8 +23,9 @@ const logger = new Rollbar({
     },
   },
 });
+
 if ('development' === process.env.NODE_ENV) {
-  //logger.configure({verbose: true});
+  // logger.configure({verbose: true});
 }
 
 module.exports = {

--- a/routes/wpt.js
+++ b/routes/wpt.js
@@ -55,7 +55,7 @@ const wtp = (app) => {
       routeCallback({status: 'error', message: 'URL is not valid'});
       return;
     }*/
-    logger.info('Started test called from webspeedtest',rollBarMsg, req);
+    logger.info('Started test called from webspeedtest', rollBarMsg, req);
     apiCaller.runWtpTest(testUrl, (error, result) => {
       routeCallback(error, result, res, rollBarMsg)
     });


### PR DESCRIPTION
The Cloudinary service has added support for both `jp2` and `avif`.
This PR adds support for both as possible variants on each WPT page analysis (Server).