### PR TITLE
remove not rendered images and reduce loging

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,6 +55,10 @@ const listenPort = process.env.PORT || 5000;
 
 const server = http.createServer(app);
 server.setTimeout(3 * 60 * 1000)
+server.on('error', (e) => {
+  console.log(e);
+})
+
 server.listen(listenPort, () => {
   logger.info('Server started listing on port ' + listenPort);
   console.log('Listening on port ' + listenPort);

--- a/cloudinary/apiCaller.js
+++ b/cloudinary/apiCaller.js
@@ -37,44 +37,52 @@ const addServerInfo = (imageList, batchSize, dpr, metaData, quality, cb, rollBar
 
 const sendToCloudinary = (imagesArray, batchSize, dpr, metaData, quality, cb, rollBarMsg) => {
   let analyzeResults = [];
+  let uploadErrors = [];
   let timestamp = Math.floor(Date.now() / 1000);
   async.eachLimit(imagesArray, batchSize, (image, callback) => {
-    let context = {
-      rendered_dimensions: {width: image.width, height: image.height},
-      dpr: dpr,
-      request_headers: metaData.headers
-    };
-    let transformations = config.get('cloudinary.transformations', null);
-    if (typeof transformations === 'string') {
-      transformations = JSON.parse(transformations);
-    }
-    let eager = [];
-    if (transformations) {
-      eager = transformations.map((trans) => {
-        let t = Object.assign({}, trans, {width: image.width, height: image.height, dpr: dpr || 1});
-        if (quality) {
-           Object.assign(t, {quality: 'auto:' + quality})
-        }
-        return t;
-      });
-    }
-    const tags = [timestamp];
-    if (image.url === metaData.lcpURL) {
-      tags.push('lcp');
-    }
-
-    cloudinary.v2.uploader.upload(image.url, {eager: eager, analyze:{context: context}, tags: tags},(error, result) => {
-      if (error) {
-        analyzeResults.push({public_id: null});
-        log.error('Error uploading to cloudinary', error, rollBarMsg);
-        callback(error);
-      } else {
-        result.server = image.server;
-        analyzeResults.push(result);
-        callback();
+    if (image.width > 0 && image.height > 0) {
+      let context = {
+        rendered_dimensions: {width: image.width, height: image.height},
+        dpr: dpr,
+        request_headers: metaData.headers
+      };
+      let transformations = config.get('cloudinary.transformations', null);
+      if (typeof transformations === 'string') {
+        transformations = JSON.parse(transformations);
       }
-    } );
+      let eager = [];
+      if (transformations) {
+        eager = transformations.map((trans) => {
+          let t = Object.assign({}, trans, {width: image.width, height: image.height, dpr: dpr || 1});
+          if (quality) {
+            Object.assign(t, {quality: 'auto:' + quality})
+          }
+          return t;
+        });
+      }
+      const tags = [timestamp];
+      if (image.url === metaData.lcpURL) {
+        tags.push('lcp');
+      }
+
+      cloudinary.v2.uploader.upload(
+          image.url, {eager: eager, analyze: {context: context}, tags: tags}, (error, result) => {
+            if (error) {
+              analyzeResults.push({public_id: null});
+              uploadErrors.push(error);
+              console.error('Error uploading to cloudinary', error);
+              callback();
+            } else {
+              result.server = image.server;
+              analyzeResults.push(result);
+              callback();
+            }
+          });
+    }
   }, err => {
+    if (uploadErrors.length > 0) {
+      log.error('cloudinary upload errors', uploadErrors, rollBarMsg);
+    }
     if (err) {
       cb({status: 'error', message: 'Error getting results from cloudinary', error: err, logLevel: logger.LOG_LEVEL_ERROR}, null, null, rollBarMsg);
     }

--- a/logger/index.js
+++ b/logger/index.js
@@ -4,12 +4,14 @@ const Rollbar = require('rollbar');
 const LOG_LEVEL_INFO = 'info';
 const LOG_LEVEL_WARNING = 'warning';
 const LOG_LEVEL_ERROR = 'error';
+const LOG_LEVEL_DEBUG = 'debug';
 const LOG_LEVEL_CRITICAL = 'critical';
 const packageJson = require('../package.json');
 const os = require('os');
 const logger = new Rollbar({
   // enabled: false,  // silence rollbar as it takes too much quota.
   accessToken: config.get('rollbar.postToken'),
+  verbose: true,
   handleUncaughtExceptions: true,
   handleUnhandledRejections: true,
   environment: process.env.NODE_ENV || process.env.HOSTNAME,
@@ -33,5 +35,6 @@ module.exports = {
   LOG_LEVEL_INFO: LOG_LEVEL_INFO,
   LOG_LEVEL_WARNING: LOG_LEVEL_WARNING,
   LOG_LEVEL_ERROR: LOG_LEVEL_ERROR,
-  LOG_LEVEL_CRITICAL: LOG_LEVEL_CRITICAL
+  LOG_LEVEL_CRITICAL: LOG_LEVEL_CRITICAL,
+  LOG_LEVEL_DEBUG: LOG_LEVEL_DEBUG
 };

--- a/wtp/wtpResultsParser.js
+++ b/wtp/wtpResultsParser.js
@@ -4,11 +4,12 @@
 
 'use strict';
 
+
 const _ = require('lodash');
 const config = require('config');
 const bytes = require('bytes');
 const logger = require('../logger').logger;
-const url = require('url');
+const URL = require('url');
 const path = require('path');
 
 const parseTestResults = (testJson) => {
@@ -32,6 +33,7 @@ const parseTestResults = (testJson) => {
       return (arrVal.width === othVal.width) && (arrVal.height === othVal.height) && (arrVal.url === othVal.url);
     });
     imageList = filterByResolution(imageList);
+    imageList = filterNotRendered(imageList);
     let origLength = imageList.length;
     imageList = _.sortBy(imageList, (img) => {
       return img.width * img.height;
@@ -93,10 +95,12 @@ const parseTestResults = (testJson) => {
   }
 };
 
+/*
 const extractFileName = (uri) => {
   let parsedUrl = url.parse(uri);
   return path.basename(parsedUrl.pathname)
 };
+*/
 
 const parseTestResponse = (body, rollBarMsg) => {
   if (body.statusText !== 'Ok') {
@@ -133,6 +137,12 @@ const filterByResolution = (imageList) => {
     return (image.naturalWidth * image.naturalHeight) <= maxRes && (image.naturalWidth * image.naturalHeight) >= minRes;
   })
 };
+
+const filterNotRendered = (imageList) => {
+  return _.filter(imageList, (image) => {
+    return !(image.width === 0 || image.height === 0)
+  })
+}
 
 
 module.exports = {


### PR DESCRIPTION
@mikeys 
1. enabled verbose on rollbar e.g. log to console too. 
2. filter out images with a width or height of 0 that caused errors in cloudinary.
3. reduced the number of errors sent to rollbar by accumulating the errors and then sending them.

There is an error that I saw a few times. URLs returned as images are pointing to the page itself or a locale of it (I guess it is because of redirects)
this causes errors when uploading to Cloudinary as it is an HTML and not an image
we can:
1. filter any image URL that has no file (we may miss some images)
2. test every image URL before uploading it (will have a performance impact)
3. leave it as is just have to know that we would see these errors in the logs.